### PR TITLE
Fix syntax error and improved examples documentation

### DIFF
--- a/tdda/constraints/examples/files_extension.py
+++ b/tdda/constraints/examples/files_extension.py
@@ -208,7 +208,6 @@ class FilesConstraintDiscoverer(FilesConstraintCalculator,
 
 
 class FilesConstraintVerifier(FilesConstraintCalculator,
-                              BaseConstraintDetector):
                               BaseConstraintVerifier):
     def __init__(self, path, type_checking='strict', **kwargs):
         FilesConstraintCalculator.__init__(self, path)

--- a/tdda/referencetest/examples.py
+++ b/tdda/referencetest/examples.py
@@ -6,8 +6,13 @@ for both :py:mod:`unittest` and :py:mod:`pytest`.
 To copy these examples to your own *referencetest-examples* subdirectory
 (or to a location of your choice), run the command::
 
-    tdda examples referencetest [mydirectory]
+    tdda examples referencetest [mydirectory] 
 
+Alternatively, you can copy all examples using the following command::
+    
+    tdda examples
+
+which will create 3 separate sub-directories.
 """
 from __future__ import absolute_import
 


### PR DESCRIPTION
Expand on the examples documentation.

Fix the bug in files_extension.py where a class definition had a syntax error.