### PR TITLE
Use bash highlighting for command line examples

### DIFF
--- a/tdda/referencetest/__init__.py
+++ b/tdda/referencetest/__init__.py
@@ -93,13 +93,17 @@ a CSV file::
     if __name__ == '__main__':
         ReferenceTestCase.main()
 
-To run the test::
+To run the test
+
+.. code-block:: bash
 
     python mytest.py
 
 The first time you run the test, it will produce an error unless you
 have already created the expected ("reference") results. You can
-create the reference results automatically::
+create the reference results automatically
+
+.. code-block:: bash
 
     python mytest.py --write-all
 
@@ -144,13 +148,17 @@ You also need a ``conftest.py`` file, to define the fixtures and defaults::
 
     referencepytest.set_default_data_location('testdata')
 
-To run the test::
+To run the test
+
+.. code-block:: bash
 
     pytest
 
 The first time you run the test, it will produce an error unless you
 have already created the expected ("reference") results. You can
-create the reference results automatically::
+create the reference results automatically
+
+.. code-block:: bash
 
     pytest --write-all -s
 

--- a/tdda/referencetest/referencepytest.py
+++ b/tdda/referencetest/referencepytest.py
@@ -56,16 +56,22 @@ If the **-s** option is also provided (to disable ``pytest``
 output capturing), it will report the names of all the files it has
 regenerated.
 
-To regenerate all reference results (or generate them for the first time)::
+To regenerate all reference results (or generate them for the first time)
 
-    pytest -s --write-all
+.. code-block:: bash
 
-To regenerate just a particular kind of reference (e.g. table results)::
+   pytest -s --write-all
+    
+To regenerate just a particular kind of reference (e.g. table results)
+
+.. code-block:: bash
 
     pytest -s --write table
 
 To regenerate a number of different kinds of reference (e.g. both table
-and graph results)::
+and graph results)
+
+.. code-block:: bash
 
     pytest -s --write table graph
 

--- a/tdda/referencetest/referencetestcase.py
+++ b/tdda/referencetest/referencetestcase.py
@@ -87,16 +87,22 @@ passing in a comma-separated list of *kind* names immediately after
 the ``--write`` option. If no list of *kind* names is provided, then all
 test results will be regenerated.
 
-To regenerate all reference results (or generate them for the first time)::
+To regenerate all reference results (or generate them for the first time)
 
-    python my_tests.py --write-all
+.. code-block:: bash
 
-To regenerate just a particular kind of reference (e.g. table results)::
+   pytest -s --write-all
+
+To regenerate just a particular kind of reference (e.g. table results)
+
+.. code-block:: bash
 
     python my_tests.py --write table
 
 To regenerate a number of different kinds of reference (e.g. both table
-and graph results)::
+and graph results)
+
+.. code-block:: bash
 
     python my_tests.py --write table graph
 


### PR DESCRIPTION
Fix cases of 'python mytest.py --write-all' appearing with the '-all' highlighted separately, caused by default python highlighting. Same change made to other command line examples, for consistency.