### PR TITLE
Fix writabletestcase.py

### DIFF
--- a/tdda/writabletestcase.py
+++ b/tdda/writabletestcase.py
@@ -113,7 +113,7 @@ def report_failure(actual_path, expected_path, ignore_patterns):
     and expected files. Also notes any exclusions in the comparison.
     """
     print('\nFile check failed.')
-    print('Compare with "diff %s %s".\n' % (actual_path, expected_path)
+    print('Compare with "diff %s %s".\n' % (actual_path, expected_path))
     if ignore_patterns:
         print('Note exclusions:')
         for pattern in ignore_patterns:


### PR DESCRIPTION
I've noticided it while refreshing package in Guix:

```
***   File "/gnu/store/jq5gml54cc33ayh8s0ikkrh12pnaq596-python-tdda-2.2.5/lib/python3.10/site-packages/tdda/writabletestcase.py", line 116
    print('Compare with "diff %s %s".\n' % (actual_path, expected_path)
         ^
SyntaxError: '(' was never closed
```